### PR TITLE
feature: public Udev and UdevList API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! Uses the [`libc`](https://crates.io/crates/libc) and [`nix`](https://crates.io/crates/nix) crate to make syscalls to Linux.
 
+use std::sync::Arc;
+
 #[macro_use]
 extern crate bitflags;
 
@@ -34,3 +36,68 @@ pub use murmur_hash::*;
 pub use queue::*;
 pub use socket::*;
 pub use util::*;
+
+/// Creates a new [Udev] context.
+pub fn udev_new() -> Arc<Udev> {
+    Arc::new(Udev::new())
+}
+
+/// Gets the [LogPriority] for the [Udev] context.
+pub fn udev_get_log_priority(udev: &Udev) -> LogPriority {
+    udev.log_priority()
+}
+
+/// Sets the [LogPriority] for the [Udev] context.
+pub fn udev_set_log_priority(udev: &mut Udev, val: LogPriority) {
+    udev.set_log_priority(val);
+}
+
+/// Gets a reference to the next entry in a [UdevList].
+///
+/// Breaks with the original `libudev` API by requiring a reference to the list, instead of a list
+/// entry. This is because the C version uses a linked-list composed of pointers, we don't.
+pub fn udev_list_entry_get_next(list: &UdevList) -> Option<&UdevEntry> {
+    list.next_entry()
+}
+
+/// Gets a mutable reference to the next entry in a [UdevList].
+///
+/// Breaks with the original `libudev` API by requiring a reference to the list, instead of a list
+/// entry. This is because the C version uses a linked-list composed of pointers, we don't.
+pub fn udev_list_entry_get_next_mut(list: &mut UdevList) -> Option<&mut UdevEntry> {
+    list.next_entry_mut()
+}
+
+/// Gets the name of the [UdevEntry].
+pub fn udev_list_entry_get_name(entry: &UdevEntry) -> &str {
+    entry.name()
+}
+
+/// Gets the value of the [UdevEntry].
+pub fn udev_list_entry_get_value(entry: &UdevEntry) -> &str {
+    entry.value()
+}
+
+/// Helper function that iterates over every [UdevEntry] in the list, applying the function to each
+/// entry.
+///
+/// Breaks with the original `libudev` API by requiring a reference to the list, instead of a list
+/// entry. This is because the C version uses a linked-list composed of pointers, we don't.
+pub fn udev_list_entry_foreach(list: &UdevList, f: fn(&UdevEntry) -> Result<()>) -> Result<()> {
+    for entry in list.iter() {
+        f(entry)?;
+    }
+    Ok(())
+}
+
+/// Helper function that iterates over every [UdevEntry] in the list, applying the function to each
+/// entry.
+///
+/// Breaks with the original `libudev` API by requiring a reference to the list, instead of a list
+/// entry. This is because the C version uses a linked-list composed of pointers, we don't.
+pub fn udev_list_entry_foreach_mut(list: &mut UdevList, f: fn(&mut UdevEntry) -> Result<()>) -> Result<()> {
+    for entry in list.iter_mut() {
+        f(entry)?;
+    }
+    Ok(())
+}

--- a/src/list.rs
+++ b/src/list.rs
@@ -99,6 +99,16 @@ impl UdevList {
         self.list.iter_mut().find(|e| e.name() == name)
     }
 
+    /// Gets the next [UdevEntry] in the list.
+    pub fn next_entry(&self) -> Option<&UdevEntry> {
+        self.list.iter().skip(self.entries_cur.saturating_sub(1)).next()
+    }
+
+    /// Gets the next [UdevEntry] in the list.
+    pub fn next_entry_mut(&mut self) -> Option<&mut UdevEntry> {
+        self.list.iter_mut().skip(self.entries_cur.saturating_sub(1)).next()
+    }
+
     /// Adds an entry to the list.
     ///
     /// If an [UdevEntry] with the same `name` exists, the `value` will be updated.


### PR DESCRIPTION
Provides helper functions for the `Udev`, `UdevList`, and `UdevEntry` public APIs.

Attempts to stay somewhat close to the original `libudev` C API, with important differences when implementation details don't allow for a 1:1 mapping, e.g. `UdevList` is a `std::collections::LinkedList`, not a collection of raw pointers.

Initial commit of providing a public API that is reasonably close to the original `libudev`.