### PR TITLE
api: add top-level public `UdevMonitor` API

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -53,11 +53,6 @@ impl UdevList {
         self.list.iter_mut()
     }
 
-    /// Gets whether the [UdevEntryList] is empty.
-    pub fn is_empty(&self) -> bool {
-        self.list.is_empty()
-    }
-
     /// Gets a reference to the [UdevEntryList].
     pub fn list(&self) -> &UdevEntryList {
         &self.list
@@ -77,6 +72,21 @@ impl UdevList {
     pub fn with_list<L: Into<UdevEntryList>>(mut self, list: L) -> Self {
         self.set_list(list);
         self
+    }
+
+    /// Gets the length of the [UdevEntry] list.
+    pub fn len(&self) -> usize {
+        self.list.len()
+    }
+
+    /// Gets whether the [UdevEntryList] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.list.is_empty()
+    }
+
+    /// Clears the list of all entries.
+    pub fn clear(&mut self) {
+        self.list.clear();
     }
 
     /// Gets an optional reference to the first [UdevEntry] in the [UdevEntryList].
@@ -167,11 +177,6 @@ impl UdevList {
                 .count()
                 != 0
         }
-    }
-
-    /// Clears the list of all entries.
-    pub fn clear(&mut self) {
-        self.list.clear();
     }
 }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -38,4 +38,44 @@ impl UdevSocket {
 
         Self::Netlink(nl)
     }
+
+    /// Gets the [UdevSocket] as a reference to a [`sockaddr_nl`](libc::sockaddr_nl).
+    ///
+    /// Returns `Err(Error)` if not a [UdevSocket::Netlink] variant.
+    pub fn as_nl(&self) -> Result<&sockaddr_nl> {
+        match self {
+            Self::Netlink(nl) => Ok(nl),
+            _ => Err(Error::Udev("socket: expected sockaddr_nl".into())),
+        }
+    }
+
+    /// Gets the [UdevSocket] as a mutable reference to a [`sockaddr_nl`](libc::sockaddr_nl).
+    ///
+    /// Returns `Err(Error)` if not a [UdevSocket::Netlink] variant.
+    pub fn as_nl_mut(&mut self) -> Result<&mut sockaddr_nl> {
+        match self {
+            Self::Netlink(nl) => Ok(nl),
+            _ => Err(Error::Udev("socket: expected sockaddr_nl".into())),
+        }
+    }
+
+    /// Gets the [UdevSocket] as a const pointer to a [`sockaddr_nl`](libc::sockaddr_nl).
+    ///
+    /// Returns `Err(Error)` if not a [UdevSocket::Netlink] variant.
+    pub fn as_nl_ptr(&self) -> Result<*const sockaddr_nl> {
+        match self {
+            Self::Netlink(nl) => Ok(nl as *const _),
+            _ => Err(Error::Udev("socket: expected sockaddr_nl".into())),
+        }
+    }
+
+    /// Gets the [UdevSocket] as a const pointer to a [`sockaddr_nl`](libc::sockaddr_nl).
+    ///
+    /// Returns `Err(Error)` if not a [UdevSocket::Netlink] variant.
+    pub fn as_nl_ptr_mut(&mut self) -> Result<*mut sockaddr_nl> {
+        match self {
+            Self::Netlink(nl) => Ok(nl as *mut _),
+            _ => Err(Error::Udev("socket: expected sockaddr_nl".into())),
+        }
+    }
 }


### PR DESCRIPTION
Adds a top-level public API for `UdevMonitor` that closely maps to the original `libudev` API.