### PR TITLE
feature: `UdevQueue` top-level API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Currently, there is only a Rust public API. Work is still ongoing to expose rema
 - [x] [UdevDevice] kernel devices
 - [x] [UdevMonitor] device monitor service
 - [x] [UdevEnumerate] device enumeration
-- [ ] [UdevQueue] device queue
+- [x] [UdevQueue] device queue
 - [ ] [UdevHwdb] device hardware database persistent storage
 - [ ] public C API via FFI
   - after the Rust API stabilizes, work can start on a C API

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,7 @@ pub enum Error {
     UdevHwdb(String),
     UdevMonitor(String),
     UdevEnumerate(String),
+    UdevQueue(String),
     Io(String),
 }
 
@@ -49,6 +50,7 @@ impl fmt::Display for Error {
             Self::UdevHwdb(err) => write!(f, "udev hwdb: {err}"),
             Self::UdevMonitor(err) => write!(f, "udev monitor: {err}"),
             Self::UdevEnumerate(err) => write!(f, "udev enumerate: {err}"),
+            Self::UdevQueue(err) => write!(f, "udev queue: {err}"),
             Self::Io(err) => write!(f, "I/O: {err}"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -889,3 +889,40 @@ pub fn udev_enumerate_scan_devices(enumerate: &mut UdevEnumerate) -> Result<()> 
 pub fn udev_enumerate_scan_subsystems(enumerate: &mut UdevEnumerate) -> Result<()> {
     enumerate.scan_subsystems()
 }
+
+/// Creates a new [UdevQueue].
+pub fn udev_queue_new(udev: Arc<Udev>) -> Arc<UdevQueue> {
+    Arc::new(UdevQueue::new(udev))
+}
+
+/// Gets a reference to the [Udev] context.
+pub fn udev_queue_get_udev(queue: &UdevQueue) -> &Arc<Udev> {
+    queue.udev()
+}
+
+/// Checks if [Udev] is active on the system.
+pub fn udev_queue_get_udev_is_active(queue: &UdevQueue) -> bool {
+    queue.udev_is_active()
+}
+
+/// Gets whether [UdevQueue] is currently processing any events.
+pub fn udev_queue_get_queue_is_empty(queue: &UdevQueue) -> bool {
+    queue.queue_is_empty()
+}
+
+/// Gets a file descriptor to watch for a queue to become empty.
+pub fn udev_queue_get_fd(queue: &mut UdevQueue) -> Result<i32> {
+    queue.get_fd()
+}
+
+/// Clears the watched file descriptor for queue changes.
+///
+/// # Safety
+///
+/// Users must ensure that every [UdevQueue] has a unique file descriptor, if the descriptor is
+/// non-negative.
+///
+/// Returns: `Ok(())` on success, `Err(Error)` otherwise.
+pub fn udev_queue_flush(queue: &mut UdevQueue) -> Result<()> {
+    queue.flush()
+}

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -7,9 +7,12 @@
 //!
 //! From `libudev-queue` documentation.
 
-use std::sync::Arc;
+use std::io::{self, Write};
+use std::os::fd::FromRawFd;
+use std::{ffi, fs, sync::Arc};
 
-use crate::{Udev, UdevEntryList, UdevList};
+use crate::UDEV_ROOT_RUN;
+use crate::{Error, Result, Udev, UdevEntryList, UdevList};
 
 /// Represents the current event queue in the udev daemon.
 #[repr(C)]
@@ -17,6 +20,7 @@ use crate::{Udev, UdevEntryList, UdevList};
 pub struct UdevQueue {
     udev: Arc<Udev>,
     queue_list: UdevList,
+    fd: i32,
 }
 
 impl UdevQueue {
@@ -26,16 +30,23 @@ impl UdevQueue {
         Self {
             udev,
             queue_list: UdevList::new(udev_arc),
+            fd: -1,
         }
     }
 
-    /// Creates a new [UdevQueue] from the provided parameter.
-    pub fn create<Q: Into<UdevEntryList>>(udev: Arc<Udev>, queue_list: Q) -> Self {
+    /// Creates a new [UdevQueue] from the provided parameters.
+    pub fn create<Q: Into<UdevEntryList>>(udev: Arc<Udev>, queue_list: Q, fd: i32) -> Self {
         let udev_arc = Arc::clone(&udev);
         Self {
             udev,
             queue_list: UdevList::create(udev_arc, queue_list.into()),
+            fd,
         }
+    }
+
+    /// Gets a reference to the [Udev] context.
+    pub const fn udev(&self) -> &Arc<Udev> {
+        &self.udev
     }
 
     /// Gets a reference to the queue list [UdevList].
@@ -58,6 +69,114 @@ impl UdevQueue {
         self.set_queue_list(queue_list);
         self
     }
+
+    /// Gets the length of the [UdevQueue].
+    pub fn len(&self) -> usize {
+        self.queue_list.len()
+    }
+
+    /// Gets whether the [UdevQueue] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.queue_list.is_empty()
+    }
+
+    /// Gets the [UdevQueue] file descriptor.
+    pub const fn fd(&self) -> i32 {
+        self.fd
+    }
+
+    /// Sets the [UdevQueue] file descriptor.
+    pub fn set_fd(&mut self, val: i32) {
+        self.fd = val;
+    }
+
+    /// Builder function that sets the [UdevQueue] file descriptor.
+    pub fn with_fd(mut self, val: i32) -> Self {
+        self.set_fd(val);
+        self
+    }
+
+    /// Gets a file descriptor to watch for a queue to become empty.
+    pub fn get_fd(&mut self) -> Result<i32> {
+        if self.fd < 0 {
+            // SAFETY: the argument is valid, and the return value is checked before use.
+            let fd = unsafe { libc::inotify_init1(libc::IN_CLOEXEC) };
+            if fd < 0 {
+                let errno = io::Error::last_os_error();
+                let err_msg =
+                    format!("unable to init inotify monitor, error: {fd}, errno: {errno}");
+                log::error!("{err_msg}");
+                Err(Error::UdevQueue(err_msg))
+            } else {
+                let udev_path = ffi::CString::new(format!("{UDEV_ROOT_RUN}/udev"))?;
+                // SAFETY: arguments are valid, and pointers reference valid memory.
+                let r = unsafe {
+                    libc::inotify_add_watch(fd, udev_path.as_ptr() as *const _, libc::IN_DELETE)
+                };
+                if r < 0 {
+                    let errno = io::Error::last_os_error();
+                    let err_msg =
+                        format!("unable to add inotify watch event, error: {r}, errno: {errno}");
+                    log::error!("{err_msg}");
+                    // SAFETY: argument is valid
+                    unsafe { libc::close(fd) };
+                    Err(Error::UdevQueue(err_msg))
+                } else {
+                    self.fd = fd;
+                    Ok(fd)
+                }
+            }
+        } else {
+            Ok(self.fd)
+        }
+    }
+
+    /// Clears the watched file descriptor for queue changes.
+    ///
+    /// # Safety
+    ///
+    /// Users must ensure that every [UdevQueue] has a unique file descriptor, if the descriptor is
+    /// non-negative.
+    ///
+    /// Returns: `Ok(())` on success, `Err(Error)` otherwise.
+    pub fn flush(&mut self) -> Result<()> {
+        let fd = self.fd;
+        if fd < 0 {
+            let err = libc::EINVAL;
+            Err(Error::UdevQueue(format!(
+                "invalid file descriptor, fd: {fd}, error: {err}"
+            )))
+        } else {
+            // SAFETY: argument is valid, and only one valid mutable reference to this UdevQueue
+            // can be held without further `unsafe` code.
+            //
+            // Users must ensure that every UdevQueue has a unique file descriptor.
+            let mut file = unsafe { fs::File::from_raw_fd(fd) };
+            file.flush().map_err(|err| {
+                let errno = io::Error::last_os_error();
+                let err_msg =
+                    format!("unable to flush queue file descriptor, error: {err}, errno: {errno}");
+                log::error!("{err_msg}");
+                Error::UdevQueue(err_msg)
+            })
+        }
+    }
+
+    /// Checks if [Udev] is active on the system.
+    pub fn udev_is_active(&self) -> bool {
+        fs::OpenOptions::new()
+            .read(true)
+            .open(format!("{UDEV_ROOT_RUN}/udev/control"))
+            .is_ok()
+    }
+
+    /// Gets whether [UdevQueue] is currently processing any events.
+    pub fn queue_is_empty(&self) -> bool {
+        fs::OpenOptions::new()
+            .read(true)
+            .open(format!("{UDEV_ROOT_RUN}/udev/queue"))
+            .is_ok()
+    }
 }
 
 #[cfg(test)]
@@ -71,7 +190,7 @@ mod tests {
         let mut null_queue = UdevQueue::new(Arc::clone(&udev));
 
         let exp_list = [UdevEntry::new().with_name("test_list_entry")];
-        let exp_queue = UdevQueue::create(Arc::clone(&udev), exp_list.clone());
+        let exp_queue = UdevQueue::create(Arc::clone(&udev), exp_list.clone(), -1);
 
         assert!(null_queue.queue_list().is_empty());
 


### PR DESCRIPTION
Adds a public, top-level `UdevQueue` API that maps closely to the original `libudev` API.

Omits deprecated functions from the `libudev` API.

Adds `UdevQueue` to the list of completed top-level APIs.