### PR TITLE
update: publishing and README info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 name = "udev"
 version = "0.1.0"
 edition = "2021"
+authors = ["udev Rust Developers"]
+description = "Pure Rust implementation of the user-land udev library"
+keywords = ["udev", "devfs", "linux", "unix"]
+categories = ["filesystem", "os", "os::linux-apis", "os::unix-apis"]
+repository = "https://github.com/cr8t/udev"
+license = "MIT"
 
 [dependencies]
 bitflags = "2.4"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyleft (c) 2023 usbfs developers 
+Copyleft (c) 2023 udev developers 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -29,17 +29,19 @@ $ cargo doc --all --open
 
 As the project matures, use-case examples will be added to doc-tests.
 
+- [x] [Udev](src/context.rs) context
+- [x] [UdevList](src/list.rs) device entry lists
+- [x] [UdevDevice](src/device.rs) kernel devices
+- [x] [UdevMonitor](src/monitor.rs) device monitor service
+- [x] [UdevEnumerate](src/enumerate.rs) device enumeration
+- [x] [UdevQueue](src/queue.rs) device queue
+- [x] [UdevHwdb](src/hwdb.rs) device hardware database persistent storage
+- [x] [Top-level API](src/lib.rs) matches closely to original `libudev` API
+  - basis for a future C API via FFI
+
 ## WIP
 
 Currently, there is only a Rust public API. Work is still ongoing to expose remaining subsystems via the top-level API:
-
-- [x] [Udev] context
-- [x] [UdevList] device entry lists
-- [x] [UdevDevice] kernel devices
-- [x] [UdevMonitor] device monitor service
-- [x] [UdevEnumerate] device enumeration
-- [x] [UdevQueue] device queue
-- [x] [UdevHwdb] device hardware database persistent storage
 - [ ] public C API via FFI
   - after the Rust API stabilizes, work can start on a C API
   - some abstractions will take some work to expose safely through the FFI barrier, e.g. `Arc<Udev>`


### PR DESCRIPTION
Adds publishing information for `crates.io`.

Updates the README with completed API information, and provides links to source files for the main library structures.