### PR TITLE
fixup: Cargo.toml: change crate name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "udev"
+name = "udevrs"
 version = "0.1.0"
 edition = "2021"
 authors = ["udev Rust Developers"]

--- a/tests/hwdb.rs
+++ b/tests/hwdb.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use udev::{Result, Udev, UdevHwdb};
+use udevrs::{Result, Udev, UdevHwdb};
 
 mod common;
 


### PR DESCRIPTION
Changes the crate name to `udevrs` because the `udev` and `libudev` crates for `libudev` bindings already exist.