### PR TITLE
version: bump to v0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udevrs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["udev Rust Developers"]
 description = "Pure Rust implementation of the user-land udev library"


### PR DESCRIPTION
Bumps the patch version to `v0.1.1` to include the `encode_string` utility function.