### PR TITLE
fixup: use proper `nl_groups` for `Monitor::snl`

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -134,7 +134,7 @@ impl UdevMonitor {
         Ok(Self {
             udev,
             sock: 0,
-            snl: UdevSocket::new_nl(libc::AF_NETLINK, 0, 0),
+            snl: UdevSocket::new_nl(libc::AF_NETLINK, 0, 2),
             snl_group: UdevMonitorNetlinkGroup::None,
             snl_trusted_sender: UdevSocket::new_nl(libc::AF_NETLINK, 0, 0),
             snl_destination: UdevSocket::new_nl(libc::AF_NETLINK, 0, 0),


### PR DESCRIPTION
Sets the default `nl_groups` value to `2` for `Monitor::snl`. This ensures that if users do not call a method that sets `snl`, the default will be valid to begin receiving `Netlink` events.

Part of resolving: #15