### PR TITLE
monitor: fix udev event notifications

### DIFF
--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -1,0 +1,16 @@
+use std::sync::Arc;
+use std::{thread, time};
+
+fn main() -> udevrs::Result<()> {
+    env_logger::init();
+    let udev = Arc::new(udevrs::Udev::new());
+    let mut monitor = udevrs::UdevMonitor::new_from_netlink(udev, "udev")?;
+
+    monitor.enable_receiving()?;
+
+    loop {
+        println!("{:?}", monitor.receive_device());
+
+        thread::sleep(time::Duration::from_secs(1));
+    }
+}

--- a/src/device.rs
+++ b/src/device.rs
@@ -1876,10 +1876,10 @@ impl UdevDevice {
         self.set_min(0);
 
         if self.devpath().is_empty() || self.subsystem().is_empty() {
-            Err(Error::Udev("device: empty devpath and/or subsystem".into()))
-        } else {
-            Ok(())
+            log::debug!("device: empty devpath and/or subsystem");
         }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Fixes the polling mechanism for UDEV events by correcting `ucred` parsing.

Adds an example, credit to @kevinmehall:
<https://github.com/cr8t/udev/issues/15#issuecomment-1913190142>

Resolves: #15