### PR TITLE
version: bump to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udevrs"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["udev Rust Developers"]
 description = "Pure Rust implementation of the user-land udev library"


### PR DESCRIPTION
Bumps the minor release version to `v0.2.0` for fixes and license change.

Includes:

- fixes `UdevMonitor` magic bytes mismatch
- fixes `nl_groups` in `Monitor::snl`
- fixes `UdevMonitor` event notifications
- changes license to LGPL-v2 or later to match `eudev`'s license