### PR TITLE
hwdb: fix trie search

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -39,6 +39,12 @@ impl file_handle {
     }
 }
 
+impl Default for file_handle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Wrapper around a syscall that returns an opaque handle that corresponds to a specified file.
 pub fn name_to_handle_at(
     dir_fd: i32,

--- a/src/hwdb.rs
+++ b/src/hwdb.rs
@@ -96,7 +96,7 @@ impl UdevHwdb {
             for path in bin_paths.split('\0') {
                 if let Ok(f) = fs::OpenOptions::new().read(true).open(path) {
                     bin_file = Some(f);
-                    hwdb_path = path.to_owned();
+                    path.clone_into(&mut hwdb_path);
                     break;
                 }
                 let errno = io::Error::last_os_error();

--- a/src/hwdb.rs
+++ b/src/hwdb.rs
@@ -220,6 +220,12 @@ impl UdevHwdb {
         self.properties_list.entry()
     }
 
+    /// Looks up a matching device modalias in the hardware database and returns the list of properties.
+    pub fn query(&mut self, modalias: &str) -> Option<&UdevList> {
+        self.get_properties_list_entry(modalias, 0)?;
+        Some(self.properties_list())
+    }
+
     /// Gets a reference to the [properties list](UdevList).
     pub const fn properties_list(&self) -> &UdevList {
         &self.properties_list

--- a/src/hwdb.rs
+++ b/src/hwdb.rs
@@ -1,9 +1,7 @@
-use std::{
-    env, fs,
-    io::{self, Read},
-    mem,
-    sync::Arc,
-};
+use std::io::{self, Read};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::{env, fs, mem};
 
 use crate::{Error, Result, Udev, UdevEntry, UdevList};
 
@@ -12,6 +10,37 @@ mod trie;
 
 pub use line::*;
 pub use trie::*;
+
+static NODE_SIZE: AtomicUsize = AtomicUsize::new(24);
+static CHILD_ENTRY_SIZE: AtomicUsize = AtomicUsize::new(16);
+static VALUE_ENTRY_SIZE: AtomicUsize = AtomicUsize::new(32);
+
+/// Gets the [Node](TrieNode) size loaded from the [TrieHeader].
+pub fn node_size() -> usize {
+    NODE_SIZE.load(Ordering::Relaxed)
+}
+
+pub(crate) fn set_node_size(val: usize) {
+    NODE_SIZE.store(val, Ordering::SeqCst);
+}
+
+/// Gets the [ChildEntry](TrieChildEntry) size loaded from the [TrieHeader].
+pub fn child_entry_size() -> usize {
+    CHILD_ENTRY_SIZE.load(Ordering::Relaxed)
+}
+
+pub(crate) fn set_child_entry_size(val: usize) {
+    CHILD_ENTRY_SIZE.store(val, Ordering::SeqCst);
+}
+
+/// Gets the [ValueEntry](TrieValueEntry) size loaded from the [TrieHeader].
+pub fn value_entry_size() -> usize {
+    VALUE_ENTRY_SIZE.load(Ordering::Relaxed)
+}
+
+pub(crate) fn set_value_entry_size(val: usize) {
+    VALUE_ENTRY_SIZE.store(val, Ordering::SeqCst);
+}
 
 #[cfg(target_os = "linux")]
 const UDEV_LIBEXEC_DIR: &str = "/usr/lib/udev";
@@ -94,10 +123,17 @@ impl UdevHwdb {
 
         let properties_list = UdevList::new(Arc::clone(&udev));
 
+        set_node_size(head.node_size() as usize);
+        set_child_entry_size(head.child_entry_size() as usize);
+        set_value_entry_size(head.value_entry_size() as usize);
+
         log::debug!("=== trie on-disk ===");
         log::debug!("tool version:           {}", head.tool_version());
         log::debug!("file size:         {:8} bytes", metadata.len());
         log::debug!("header size:       {:8} bytes", head.header_size());
+        log::debug!("node size:         {:8} bytes", head.node_size());
+        log::debug!("child size:        {:8} bytes", head.child_entry_size());
+        log::debug!("value size:        {:8} bytes", head.value_entry_size());
         log::debug!("strings:           {:8} bytes", head.strings_len());
         log::debug!("nodes:             {:8} bytes", head.nodes_len());
 
@@ -108,6 +144,11 @@ impl UdevHwdb {
             head,
             properties_list,
         })
+    }
+
+    /// Gets a reference to the [TrieHeader].
+    pub const fn header(&self) -> &TrieHeader {
+        &self.head
     }
 
     /// Looks up a matching device in the hardware database.
@@ -179,6 +220,11 @@ impl UdevHwdb {
         self.properties_list.entry()
     }
 
+    /// Gets a reference to the [properties list](UdevList).
+    pub const fn properties_list(&self) -> &UdevList {
+        &self.properties_list
+    }
+
     /// Adds a key-value pair to the property list.
     pub fn add_property(&mut self, key: &str, value: &str) -> Result<()> {
         Self::_add_property(&mut self.properties_list, key, value)
@@ -197,7 +243,10 @@ impl UdevHwdb {
     }
 
     /// Parses all [TrieEntry] nodes from an in-memory HWDB buffer.
-    pub fn parse_nodes(head: &TrieHeader, hwdb_buf: &[u8]) -> Result<Vec<TrieEntry>> {
+    pub fn parse_nodes<'a>(
+        head: &'a TrieHeader,
+        hwdb_buf: &'a [u8],
+    ) -> impl Iterator<Item = TrieEntry> + 'a {
         let nodes_len = head.nodes_len() as usize;
         let node_start = mem::size_of::<TrieHeader>();
         let node_end = node_start.saturating_add(nodes_len);
@@ -205,20 +254,25 @@ impl UdevHwdb {
         let buf_len = hwdb_buf.len();
 
         let mut idx = node_start;
-        // reserve an estimate of the `TrieEntry` list total size
-        let mut entries: Vec<TrieEntry> =
-            Vec::with_capacity(nodes_len.saturating_div(mem::size_of::<TrieNode>()));
 
-        if (0..buf_len).contains(&node_start) && (0..buf_len).contains(&node_end) {
-            while let Ok(entry) = TrieEntry::try_from(&hwdb_buf[idx..]) {
-                idx = idx.saturating_add(entry.len());
-                entries.push(entry);
+        std::iter::from_fn(move || {
+            if (0..buf_len).contains(&node_start)
+                && (0..buf_len).contains(&node_end)
+                && idx < nodes_len
+            {
+                TrieEntry::try_from(&hwdb_buf[idx..])
+                    .map(|entry| {
+                        idx = idx.saturating_add(entry.len());
+                        entry
+                    })
+                    .map_err(|err| {
+                        log::error!("Error parsing TrieEntry: {err}");
+                    })
+                    .ok()
+            } else {
+                None
             }
-        }
-
-        entries.reverse();
-
-        Ok(entries)
+        })
     }
 
     fn trie_search(
@@ -237,52 +291,60 @@ impl UdevHwdb {
             None
         };
 
+        log::trace!("Search term: {search}");
         let search_count = search.chars().count();
 
         while let Some(n) = node {
             let prefix_off = n.node().prefix_off() as usize;
             if prefix_off > 0 {
-                for (p, c) in trie_string(hwdb_buf, prefix_off).chars().enumerate() {
+                let ts = trie_string(hwdb_buf, prefix_off);
+                for (p, c) in ts.chars().enumerate() {
                     if c == '*' || c == '?' || c == '[' {
-                        return line_buf.trie_fnmatch(list, hwdb_buf, &n, p, search);
+                        return line_buf.trie_fnmatch(list, hwdb_buf, &n, p, &search[i + p..]);
                     }
-                    let i = i.saturating_add(p);
-                    if search_count > i && Some(c) != search.chars().nth(i) {
+                    if search_count > i && Some(c) != search.chars().nth(i + p) {
                         return Ok(());
                     }
                 }
+
+                i = i.saturating_add(ts.chars().count());
             }
 
             if let Some(child) = n.lookup_child(hwdb_buf, b'*') {
+                log::trace!("found matching child entry (glob): {child:?}");
                 line_buf.add_char(b'*')?;
                 line_buf.trie_fnmatch(list, hwdb_buf, &child, 0, &search[i..])?;
                 line_buf.remove_char();
             }
 
             if let Some(child) = n.lookup_child(hwdb_buf, b'?') {
+                log::trace!("found matching child entry (optional): {child:?}");
                 line_buf.add_char(b'?')?;
                 line_buf.trie_fnmatch(list, hwdb_buf, &child, 0, &search[i..])?;
                 line_buf.remove_char();
             }
 
             if let Some(child) = n.lookup_child(hwdb_buf, b'[') {
+                log::trace!("found matching child entry (range): {child:?}");
                 line_buf.add_char(b'[')?;
                 line_buf.trie_fnmatch(list, hwdb_buf, &child, 0, &search[i..])?;
                 line_buf.remove_char();
             }
 
-            if search.chars().nth(i) == Some('\0') {
+            if search.chars().nth(i) == Some('\0') || i >= search_count || i >= search.len() {
                 for value in n.values().iter() {
-                    Self::_add_property(
-                        list,
-                        trie_string(hwdb_buf, value.key_off() as usize),
-                        trie_string(hwdb_buf, value.value_off() as usize),
-                    )?;
+                    let key_str = trie_string(hwdb_buf, value.key_off() as usize);
+                    let val_str = trie_string(hwdb_buf, value.value_off() as usize);
+
+                    log::trace!("Matching property, key: {key_str}, value: {val_str}");
+
+                    Self::_add_property(list, key_str, val_str)?;
                 }
             }
 
             node = n.lookup_child(hwdb_buf, *search.as_bytes().get(i).unwrap_or(&0));
             i = i.saturating_add(1);
+            log::trace!("No match found, searching next child[{i}]: {node:?}");
         }
 
         Ok(())

--- a/src/hwdb/line.rs
+++ b/src/hwdb/line.rs
@@ -76,13 +76,19 @@ impl LineBuf {
         let prefix = trie_string(hwdb_buf, prefix_off);
         let prefix_len = prefix.len();
 
+        log::trace!(
+            "Entering fnmatch, prefix: {prefix}, glob: {}, search: {search}",
+            self.get()
+        );
+
         let (start, end) = if p < search.len() {
             // search for nul-terminator, or use the length of the string as terminator
             (
                 p,
-                search[p..]
+                search
                     .as_bytes()
                     .iter()
+                    .skip(p)
                     .position(|c| c == &b'\0')
                     .unwrap_or(search.len()),
             )
@@ -110,6 +116,7 @@ impl LineBuf {
         }
 
         if glob::Pattern::new(self.get())?.matches(search) {
+            log::trace!("Found matching entry, entry: {entry:?}, search: {search}");
             for value in entry.values().iter() {
                 UdevHwdb::_add_property(
                     list,

--- a/src/hwdb/line.rs
+++ b/src/hwdb/line.rs
@@ -74,6 +74,7 @@ impl LineBuf {
     ) -> Result<()> {
         let prefix_off = entry.node().prefix_off() as usize;
         let prefix = trie_string(hwdb_buf, prefix_off);
+        let prefix_len = prefix.len();
 
         let (start, end) = if p < search.len() {
             // search for nul-terminator, or use the length of the string as terminator
@@ -89,7 +90,9 @@ impl LineBuf {
             (0, 0)
         };
 
-        self.add(&prefix[start..end])?;
+        if start <= prefix_len && end <= prefix_len && start <= end {
+            self.add(&prefix[start..end])?;
+        }
 
         for child in entry.children().iter() {
             self.add_char(child.c())?;

--- a/src/hwdb/trie.rs
+++ b/src/hwdb/trie.rs
@@ -23,7 +23,7 @@ pub fn trie_string(hwdb_buf: &[u8], offset: usize) -> &str {
             .iter()
             .position(|c| c == &b'\0' || c == &b'\n')
         {
-            end
+            offset + end
         } else {
             buf_len
         };

--- a/src/hwdb/trie.rs
+++ b/src/hwdb/trie.rs
@@ -19,14 +19,12 @@ pub const HWDB_SIG_STR: &str = "KSLPHHRH";
 pub fn trie_string(hwdb_buf: &[u8], offset: usize) -> &str {
     let buf_len = hwdb_buf.len();
     if (0..buf_len).contains(&offset) {
-        let str_end = if let Some(end) = hwdb_buf[offset..]
+        let str_end = hwdb_buf[offset..]
             .iter()
             .position(|c| c == &b'\0' || c == &b'\n')
-        {
-            offset + end
-        } else {
-            buf_len
-        };
+            .map(|end| offset + end)
+            .unwrap_or(buf_len);
+
         std::str::from_utf8(&hwdb_buf[offset..str_end]).unwrap_or("")
     } else {
         ""

--- a/src/hwdb/trie/child_entry.rs
+++ b/src/hwdb/trie/child_entry.rs
@@ -1,6 +1,6 @@
-use std::{cmp, mem};
+use std::cmp;
 
-use crate::{Error, Result};
+use crate::{hwdb, Error, Result};
 
 /// Trie child entry in the hardware database.
 ///
@@ -21,6 +21,16 @@ impl TrieChildEntry {
             _padding: [0u8; 7],
             child_off: 0,
         }
+    }
+
+    /// Gets the length of the encoded [TrieChildEntry].
+    pub fn len(&self) -> usize {
+        hwdb::child_entry_size()
+    }
+
+    /// Gets whether the [TrieChildEntry] is empty.
+    pub const fn is_empty(&self) -> bool {
+        false
     }
 
     /// Gets the index of the child node.
@@ -60,9 +70,10 @@ impl TryFrom<&[u8]> for TrieChildEntry {
     type Error = Error;
 
     fn try_from(val: &[u8]) -> Result<Self> {
-        if val.len() < mem::size_of::<Self>() {
+        if val.len() < hwdb::child_entry_size() {
             Err(Error::InvalidLen(val.len()))
         } else {
+            // TODO: parse use get ranges and offsets
             let mut idx = 0usize;
 
             let c = val[idx];

--- a/src/hwdb/trie/entry.rs
+++ b/src/hwdb/trie/entry.rs
@@ -81,6 +81,12 @@ impl TrieEntry {
     }
 }
 
+impl Default for TrieEntry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TryFrom<&[u8]> for TrieEntry {
     type Error = Error;
 

--- a/src/hwdb/trie/value_entry.rs
+++ b/src/hwdb/trie/value_entry.rs
@@ -1,6 +1,6 @@
 use std::mem;
 
-use crate::{Error, Result};
+use crate::{hwdb, Error, Result};
 
 /// Trie value entry in the hardware database.
 ///
@@ -19,6 +19,16 @@ impl TrieValueEntry {
             key_off: 0,
             value_off: 0,
         }
+    }
+
+    /// Gets the length of the encoded [TrieValueEntry].
+    pub fn len(&self) -> usize {
+        hwdb::value_entry_size()
+    }
+
+    /// Gets whether the [TrieValueEntry] is empty.
+    pub const fn is_empty(&self) -> bool {
+        false
     }
 
     /// Gets key offset.
@@ -58,9 +68,10 @@ impl TryFrom<&[u8]> for TrieValueEntry {
     type Error = Error;
 
     fn try_from(val: &[u8]) -> Result<Self> {
-        if val.len() < mem::size_of::<Self>() {
+        if val.len() < hwdb::value_entry_size() {
             Err(Error::InvalidLen(val.len()))
         } else {
+            // TODO: parse use get ranges and offsets
             let mut idx = 0usize;
 
             let key_off = u64::from_le_bytes(val[idx..idx + 8].try_into()?);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -964,6 +964,34 @@ pub fn udev_hwdb_get_properties_list_entry<'h>(
     hwdb.get_properties_list_entry(modalias, flags)
 }
 
+/// Looks up a matching device modalias in the hardware database and returns the list of properties.
+pub fn udev_hwdb_query<'h>(hwdb: &'h mut UdevHwdb, modalias: &str) -> Option<&'h UdevList> {
+    // populate list if modalias is present and return
+    if hwdb.get_properties_list_entry(modalias, 0).is_some() {
+        Some(hwdb.properties_list())
+    } else {
+        None
+    }
+}
+
+/// Looks up a specific matching property name (key) for device modalias
+///
+/// ```no_run
+/// use std::sync::Arc;
+/// use udevrs::{Udev, UdevHwdb};
+/// let udev = Arc::new(Udev::new());
+///
+/// let query = udevrs::udev_hwdb_query_one(&mut UdevHwdb::new(udev).unwrap(), "usb:v1D6Bp0001", "ID_VENDOR_FROM_DATABASE");
+/// assert_eq!(query, Some("Linux Foundation".to_string()));
+/// ```
+pub fn udev_hwdb_query_one(hwdb: &mut UdevHwdb, modalias: &str, name: &str) -> Option<String> {
+    udev_hwdb_query(hwdb, modalias).and_then(|list| {
+        list.iter()
+            .find(|e| e.name() == name)
+            .map(|e| e.value().to_owned())
+    })
+}
+
 /// Encodes provided string, removing potentially unsafe characters.
 ///
 /// From the `libudev` documentation:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -967,11 +967,7 @@ pub fn udev_hwdb_get_properties_list_entry<'h>(
 /// Looks up a matching device modalias in the hardware database and returns the list of properties.
 pub fn udev_hwdb_query<'h>(hwdb: &'h mut UdevHwdb, modalias: &str) -> Option<&'h UdevList> {
     // populate list if modalias is present and return
-    if hwdb.get_properties_list_entry(modalias, 0).is_some() {
-        Some(hwdb.properties_list())
-    } else {
-        None
-    }
+    hwdb.query(modalias)
 }
 
 /// Looks up a specific matching property name (key) for device modalias
@@ -981,15 +977,17 @@ pub fn udev_hwdb_query<'h>(hwdb: &'h mut UdevHwdb, modalias: &str) -> Option<&'h
 /// use udevrs::{Udev, UdevHwdb};
 /// let udev = Arc::new(Udev::new());
 ///
-/// let query = udevrs::udev_hwdb_query_one(&mut UdevHwdb::new(udev).unwrap(), "usb:v1D6Bp0001", "ID_VENDOR_FROM_DATABASE");
-/// assert_eq!(query, Some("Linux Foundation".to_string()));
+/// let mut hwdb = UdevHwdb::new(udev).unwrap();
+/// let query = udevrs::udev_hwdb_query_one(&mut hwdb, "usb:v1D6Bp0001", "ID_VENDOR_FROM_DATABASE");
+/// assert_eq!(query, Some("Linux Foundation"));
 /// ```
-pub fn udev_hwdb_query_one(hwdb: &mut UdevHwdb, modalias: &str, name: &str) -> Option<String> {
-    udev_hwdb_query(hwdb, modalias).and_then(|list| {
-        list.iter()
-            .find(|e| e.name() == name)
-            .map(|e| e.value().to_owned())
-    })
+pub fn udev_hwdb_query_one<'h>(
+    hwdb: &'h mut UdevHwdb,
+    modalias: &str,
+    name: &str,
+) -> Option<&'h str> {
+    hwdb.query(modalias)
+        .and_then(|list| list.iter().find(|e| e.name() == name).map(|e| e.value()))
 }
 
 /// Encodes provided string, removing potentially unsafe characters.

--- a/src/list.rs
+++ b/src/list.rs
@@ -9,7 +9,7 @@ use crate::{Udev, UdevDevice};
 /// Convenience alias for a [LinkedList] of [UdevEntry].
 pub type UdevEntryList = LinkedList<UdevEntry>;
 
-///
+/// Represents a list wrapper around a [UdevEntryList].
 #[repr(C)]
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct UdevList {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -108,6 +108,11 @@ impl<const N: usize> BpfFilters<N> {
         }
     }
 }
+impl<const N: usize> Default for BpfFilters<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Handles device event sources.
 pub struct UdevMonitor {

--- a/src/util/device_nodes.rs
+++ b/src/util/device_nodes.rs
@@ -2,9 +2,9 @@ use crate::{Error, Result};
 
 /// Gets whether the provided character is whitelisted.
 pub fn whitelisted_char_for_devnode(c: char, white: &str) -> bool {
-    ('0'..='9').contains(&c)
-        || ('A'..='Z').contains(&c)
-        || ('a'..='z').contains(&c)
+    c.is_ascii_digit()
+        || c.is_ascii_uppercase()
+        || c.is_ascii_lowercase()
         || "#+-.:=@_".contains(|s| s == c)
         || white.contains(|s| s == c)
 }

--- a/tests/hwdb.rs
+++ b/tests/hwdb.rs
@@ -11,7 +11,11 @@ fn parse_hwdb() -> Result<()> {
     std::env::set_var("UDEV_HWDB_BIN", "./hwdb.bin");
     let udev = Arc::new(Udev::new());
 
-    let _hwdb = UdevHwdb::new(udev)?;
+    let mut hwdb = UdevHwdb::new(udev)?;
+
+    let entry = hwdb.get_properties_list_entry("usb:v1D6Bp0001", 0).unwrap();
+
+    assert_eq!(entry.value(), "Linux Foundation");
 
     Ok(())
 }

--- a/tests/hwdb.rs
+++ b/tests/hwdb.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use udevrs::{Result, Udev, UdevHwdb};
+use udevrs::{Error, Result, Udev, UdevHwdb};
 
 mod common;
 
@@ -13,9 +13,19 @@ fn parse_hwdb() -> Result<()> {
 
     let mut hwdb = UdevHwdb::new(udev)?;
 
-    let entry = hwdb.get_properties_list_entry("usb:v1D6Bp0001", 0).unwrap();
+    let _ = hwdb
+        .get_properties_list_entry("usb:v1D6Bp0001", 0)
+        .ok_or(Error::UdevHwdb("no matching entry found".into()))?;
 
-    assert_eq!(entry.value(), "Linux Foundation");
+    let exp = ("ID_VENDOR_FROM_DATABASE", "Linux Foundation");
+
+    let found = hwdb
+        .properties_list()
+        .iter()
+        .find(|e| e.value() == "Linux Foundation")
+        .map(|e| (e.name(), e.value()));
+
+    assert_eq!(found, Some(exp));
 
     Ok(())
 }


### PR DESCRIPTION
Fixes broken HWDB trie search algorithm.

Trie node and entry parsing now uses sizes parsed from the HWDB header.

The inner index in `trie_search` is updated properly following the `eudev` implementation.

Further refactoring is needed to bring the implementation closer to idiomatic Rust.

Includes fixes from John Whittington <git@jbrengineering.co.uk> (many thanks :)

Resolves: https://github.com/cr8t/udev/issues/22