### PR TITLE
version: bump to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udevrs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["udev Rust Developers"]
 description = "Pure Rust implementation of the user-land udev library"


### PR DESCRIPTION
Bumps the minor release version for API changes, and fixes for the trie search and node parsing algorithms.