### PR TITLE
Fix Line trie_fnmatch using search string for prefix slice

### DIFF
--- a/examples/systemd-hwdb.rs
+++ b/examples/systemd-hwdb.rs
@@ -1,0 +1,31 @@
+use std::env;
+use std::process;
+use udevrs::{udev_new, UdevHwdb};
+
+/// Simple program to query the systemd hwdb like `systemd-hwdb`
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() != 2 {
+        eprintln!("Usage: {} <hwdb_key>", args[0]);
+        process::exit(1);
+    }
+
+    let key = &args[1];
+
+    // Initialize the Hwdb
+    let mut hwdb = match UdevHwdb::new(udev_new()) {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Failed to initialize hwdb: {}", e);
+            process::exit(1);
+        }
+    };
+
+    // Query the hwdb with the provided key
+    if let Some(properties) = hwdb.query(key) {
+        properties
+            .iter()
+            .for_each(|e| println!("{}: {}", e.name(), e.value()));
+    };
+}

--- a/examples/systemd-hwdb.rs
+++ b/examples/systemd-hwdb.rs
@@ -4,6 +4,7 @@ use udevrs::{udev_new, UdevHwdb};
 
 /// Simple program to query the systemd hwdb like `systemd-hwdb`
 fn main() {
+    env_logger::init();
     let args: Vec<String> = env::args().collect();
 
     if args.len() != 2 {
@@ -23,6 +24,7 @@ fn main() {
     };
 
     // Query the hwdb with the provided key
+    log::info!("Querying hwdb with key: {}", key);
     if let Some(properties) = hwdb.query(key) {
         properties
             .iter()

--- a/src/hwdb.rs
+++ b/src/hwdb.rs
@@ -238,6 +238,8 @@ impl UdevHwdb {
 
     pub(crate) fn _add_property(list: &mut UdevList, key: &str, value: &str) -> Result<()> {
         if let Some(nkey) = key.strip_prefix(' ') {
+            // TODO - should check priority if existing: https://github.com/systemd/systemd/blob/main/src/libsystemd/sd-hwdb/sd-hwdb.c#L134
+            // add_entry if UdevList.unique (default) will replace currently
             list.add_entry(nkey, value)
                 .map(|_| ())
                 .ok_or(Error::UdevHwdb("unable to add property".into()))
@@ -267,9 +269,8 @@ impl UdevHwdb {
                 && idx < nodes_len
             {
                 TrieEntry::try_from(&hwdb_buf[idx..])
-                    .map(|entry| {
+                    .inspect(|entry| {
                         idx = idx.saturating_add(entry.len());
-                        entry
                     })
                     .map_err(|err| {
                         log::error!("Error parsing TrieEntry: {err}");
@@ -298,17 +299,18 @@ impl UdevHwdb {
         };
 
         log::trace!("Search term: {search}");
-        let search_count = search.chars().count();
 
         while let Some(n) = node {
-            let prefix_off = n.node().prefix_off() as usize;
-            if prefix_off > 0 {
+            if n.node().prefix_off() > 0 {
+                let prefix_off = n.node().prefix_off() as usize;
                 let ts = trie_string(hwdb_buf, prefix_off);
+
                 for (p, c) in ts.chars().enumerate() {
                     if c == '*' || c == '?' || c == '[' {
                         return line_buf.trie_fnmatch(list, hwdb_buf, &n, p, &search[i + p..]);
                     }
-                    if search_count > i && Some(c) != search.chars().nth(i + p) {
+
+                    if search.chars().nth(i + p) != Some(c) {
                         return Ok(());
                     }
                 }
@@ -316,34 +318,21 @@ impl UdevHwdb {
                 i = i.saturating_add(ts.chars().count());
             }
 
-            if let Some(child) = n.lookup_child(hwdb_buf, b'*') {
-                log::trace!("found matching child entry (glob): {child:?}");
-                line_buf.add_char(b'*')?;
-                line_buf.trie_fnmatch(list, hwdb_buf, &child, 0, &search[i..])?;
-                line_buf.remove_char();
+            for wildcard in [b'*', b'?', b'['] {
+                if let Some(child) = n.lookup_child(hwdb_buf, wildcard) {
+                    line_buf.add_char(wildcard)?;
+                    log::trace!("wildcard ({wildcard:?}) child match: child: {child:?}");
+                    line_buf.trie_fnmatch(list, hwdb_buf, &child, 0, &search[i..])?;
+                    line_buf.remove_char();
+                }
             }
 
-            if let Some(child) = n.lookup_child(hwdb_buf, b'?') {
-                log::trace!("found matching child entry (optional): {child:?}");
-                line_buf.add_char(b'?')?;
-                line_buf.trie_fnmatch(list, hwdb_buf, &child, 0, &search[i..])?;
-                line_buf.remove_char();
-            }
-
-            if let Some(child) = n.lookup_child(hwdb_buf, b'[') {
-                log::trace!("found matching child entry (range): {child:?}");
-                line_buf.add_char(b'[')?;
-                line_buf.trie_fnmatch(list, hwdb_buf, &child, 0, &search[i..])?;
-                line_buf.remove_char();
-            }
-
-            if search.chars().nth(i) == Some('\0') || i >= search_count || i >= search.len() {
+            if search.chars().nth(i) == Some('\0') {
                 for value in n.values().iter() {
                     let key_str = trie_string(hwdb_buf, value.key_off() as usize);
                     let val_str = trie_string(hwdb_buf, value.value_off() as usize);
 
                     log::trace!("Matching property, key: {key_str}, value: {val_str}");
-
                     Self::_add_property(list, key_str, val_str)?;
                 }
             }

--- a/src/hwdb.rs
+++ b/src/hwdb.rs
@@ -303,7 +303,7 @@ impl UdevHwdb {
         while let Some(n) = node {
             if n.node().prefix_off() > 0 {
                 let prefix_off = n.node().prefix_off() as usize;
-                let ts = trie_string(hwdb_buf, prefix_off);
+                let ts = trie_string(hwdb_buf, prefix_off)?;
 
                 for (p, c) in ts.chars().enumerate() {
                     if c == '*' || c == '?' || c == '[' {
@@ -329,8 +329,8 @@ impl UdevHwdb {
 
             if search.chars().nth(i) == Some('\0') {
                 for value in n.values().iter() {
-                    let key_str = trie_string(hwdb_buf, value.key_off() as usize);
-                    let val_str = trie_string(hwdb_buf, value.value_off() as usize);
+                    let key_str = trie_string(hwdb_buf, value.key_off() as usize)?;
+                    let val_str = trie_string(hwdb_buf, value.value_off() as usize)?;
 
                     log::trace!("Matching property, key: {key_str}, value: {val_str}");
                     Self::_add_property(list, key_str, val_str)?;

--- a/src/hwdb/line.rs
+++ b/src/hwdb/line.rs
@@ -1,6 +1,6 @@
-use heapless::Vec;
 use super::trie_string;
 use crate::{Error, Result, TrieEntry, UdevHwdb, UdevList};
+use heapless::Vec;
 
 /// Maximum length for a file line.
 pub const LINE_MAX: usize = 4096;
@@ -79,15 +79,15 @@ impl LineBuf {
             self.get()
         );
 
-        let (start, end) =
-            (
-                p,
-                prefix.as_bytes()
-                    .iter()
-                    .skip(p)
-                    .position(|c| *c == b'\0')
-                    .unwrap_or(prefix_len),
-            );
+        let (start, end) = (
+            p,
+            prefix
+                .as_bytes()
+                .iter()
+                .skip(p)
+                .position(|c| *c == b'\0')
+                .unwrap_or(prefix_len),
+        );
 
         // the logic of add only if within bounds but always remove is odd but the linebuf_add return is not checked in https://github.com/cr8t/udev/issues/25#L187
         // so behavior should match

--- a/src/hwdb/line.rs
+++ b/src/hwdb/line.rs
@@ -71,7 +71,7 @@ impl LineBuf {
         search: &str,
     ) -> Result<()> {
         let prefix_off = entry.node().prefix_off() as usize;
-        let prefix = trie_string(hwdb_buf, prefix_off);
+        let prefix = trie_string(hwdb_buf, prefix_off)?;
         let prefix_len = prefix.len();
 
         log::trace!(
@@ -115,8 +115,8 @@ impl LineBuf {
             for value in entry.values().iter() {
                 UdevHwdb::_add_property(
                     list,
-                    trie_string(hwdb_buf, value.key_off() as usize),
-                    trie_string(hwdb_buf, value.value_off() as usize),
+                    trie_string(hwdb_buf, value.key_off() as usize)?,
+                    trie_string(hwdb_buf, value.value_off() as usize)?,
                 )?;
             }
         }

--- a/src/hwdb/line.rs
+++ b/src/hwdb/line.rs
@@ -91,7 +91,7 @@ impl LineBuf {
 
         // the logic of add only if within bounds but always remove is odd but the linebuf_add return is not checked in https://github.com/cr8t/udev/issues/25#L187
         // so behavior should match
-        if start < prefix_len && end <= prefix_len {
+        if (start..=end).contains(&prefix_len) {
             self.add(&prefix[start..end])?;
         }
 

--- a/src/hwdb/trie.rs
+++ b/src/hwdb/trie.rs
@@ -25,8 +25,8 @@ pub fn trie_string(hwdb_buf: &[u8], offset: usize) -> &str {
             .map(|end| offset + end)
             .unwrap_or(buf_len);
 
-        std::str::from_utf8(&hwdb_buf[offset..str_end]).unwrap_or("")
+        std::str::from_utf8(&hwdb_buf[offset..str_end]).expect("invalid UTF-8 string")
     } else {
-        ""
+        panic!("invalid trie_string offset: {}", offset);
     }
 }

--- a/src/hwdb/trie.rs
+++ b/src/hwdb/trie.rs
@@ -4,6 +4,7 @@ mod header;
 mod node;
 mod value_entry;
 
+use crate::{Error, Result};
 pub use child_entry::*;
 pub use entry::*;
 pub use header::*;
@@ -16,7 +17,7 @@ pub const HWDB_SIG: [u8; 8] = [b'K', b'S', b'L', b'P', b'H', b'H', b'R', b'H'];
 pub const HWDB_SIG_STR: &str = "KSLPHHRH";
 
 /// Parses a string from the HWDB buffer.
-pub fn trie_string(hwdb_buf: &[u8], offset: usize) -> &str {
+pub fn trie_string(hwdb_buf: &[u8], offset: usize) -> Result<&str> {
     let buf_len = hwdb_buf.len();
     if (0..buf_len).contains(&offset) {
         let str_end = hwdb_buf[offset..]
@@ -25,8 +26,9 @@ pub fn trie_string(hwdb_buf: &[u8], offset: usize) -> &str {
             .map(|end| offset + end)
             .unwrap_or(buf_len);
 
-        std::str::from_utf8(&hwdb_buf[offset..str_end]).expect("invalid UTF-8 string")
+        std::str::from_utf8(&hwdb_buf[offset..str_end])
+            .map_err(|_| Error::UdevHwdb("failed to parse utf-8 trie_string".to_string()))
     } else {
-        panic!("invalid trie_string offset: {}", offset);
+        Err(Error::UdevHwdb("invalid trie_string offset".to_string()))
     }
 }

--- a/src/hwdb/trie/child_entry.rs
+++ b/src/hwdb/trie/child_entry.rs
@@ -82,7 +82,7 @@ impl TryFrom<&[u8]> for TrieChildEntry {
             // skip `c` index + padding
             idx += 8;
 
-            let child_off = u64::from_le_bytes(val[idx..idx + 8].try_into()?);
+            let child_off = u64::from_le_bytes(val[idx..idx + std::mem::size_of::<u64>()].try_into()?);
 
             Ok(Self {
                 c,

--- a/src/hwdb/trie/child_entry.rs
+++ b/src/hwdb/trie/child_entry.rs
@@ -82,7 +82,8 @@ impl TryFrom<&[u8]> for TrieChildEntry {
             // skip `c` index + padding
             idx += 8;
 
-            let child_off = u64::from_le_bytes(val[idx..idx + std::mem::size_of::<u64>()].try_into()?);
+            let child_off =
+                u64::from_le_bytes(val[idx..idx + std::mem::size_of::<u64>()].try_into()?);
 
             Ok(Self {
                 c,

--- a/src/hwdb/trie/entry.rs
+++ b/src/hwdb/trie/entry.rs
@@ -1,4 +1,4 @@
-use std::{cmp, mem};
+use std::mem;
 
 use crate::{hwdb, Error, Result};
 
@@ -65,11 +65,11 @@ impl TrieEntry {
         let search = TrieChildEntry::new().with_c(c);
         let buf_len = hwdb_buf.len();
 
-        // search for a `TrieChildEntry` with the same child index
-        let child = self
-            .children
-            .iter()
-            .find(|&c| c.partial_cmp(&search) == Some(cmp::Ordering::Equal))?;
+        // assuming children are sorted (done in initialisation), perform a binary search instead like C hwdb
+        let child = self.children.binary_search_by(|child| child.cmp(&search))
+            .ok()
+            .and_then(|idx| self.children.get(idx))?;
+
         let child_off = child.child_off() as usize;
 
         // if the child offset is in range, attempt to construct a `TrieNode` at that offset

--- a/src/hwdb/trie/entry.rs
+++ b/src/hwdb/trie/entry.rs
@@ -66,7 +66,9 @@ impl TrieEntry {
         let buf_len = hwdb_buf.len();
 
         // assuming children are sorted (done in initialisation), perform a binary search instead like C hwdb
-        let child = self.children.binary_search_by(|child| child.cmp(&search))
+        let child = self
+            .children
+            .binary_search_by(|child| child.cmp(&search))
             .ok()
             .and_then(|idx| self.children.get(idx))?;
 

--- a/src/hwdb/trie/value_entry.rs
+++ b/src/hwdb/trie/value_entry.rs
@@ -73,11 +73,13 @@ impl TryFrom<&[u8]> for TrieValueEntry {
         } else {
             // TODO: parse use get ranges and offsets
             let mut idx = 0usize;
+            let mut idx_end = mem::size_of::<u64>();
 
-            let key_off = u64::from_le_bytes(val[idx..idx + 8].try_into()?);
-            idx += mem::size_of::<u64>();
+            let key_off = u64::from_le_bytes(val[idx..idx_end].try_into()?);
+            idx += idx_end;
+            idx_end += idx_end;
 
-            let value_off = u64::from_le_bytes(val[idx..idx + 8].try_into()?);
+            let value_off = u64::from_le_bytes(val[idx..idx_end].try_into()?);
 
             Ok(Self { key_off, value_off })
         }

--- a/src/list.rs
+++ b/src/list.rs
@@ -28,7 +28,7 @@ impl UdevList {
             list: LinkedList::new(),
             entries_cur: 0,
             entries_max: 0,
-            unique: false,
+            unique: true,
         }
     }
 
@@ -39,7 +39,7 @@ impl UdevList {
             list,
             entries_cur: 0,
             entries_max: 0,
-            unique: false,
+            unique: true,
         }
     }
 
@@ -125,15 +125,13 @@ impl UdevList {
     ///
     /// If `value` is empty, the entry value with be empty.
     pub fn add_entry(&mut self, name: &str, value: &str) -> Option<&UdevEntry> {
-        if self.unique() {
-            if self.entry_by_name(name).is_some() {
-                self.entry_by_name_mut(name).unwrap().set_value(value);
-            } else {
-                self.list
-                    .push_back(UdevEntry::new().with_name(name).with_value(value));
-            }
-            self.entry_by_name(name)
+        if self.unique() && self.entry_by_name(name).is_some() {
+            let existing = self.entry_by_name_mut(name).unwrap();
+            log::trace!("Updating property, {name}: {} => {value}", existing.value());
+            existing.set_value(value);
+            Some(existing)
         } else {
+            log::trace!("Adding property, {name}: {value}");
             self.list
                 .push_back(UdevEntry::new().with_name(name).with_value(value));
             self.list.back()

--- a/tests/hwdb.rs
+++ b/tests/hwdb.rs
@@ -14,7 +14,11 @@ fn parse_hwdb() -> Result<()> {
     let mut hwdb = UdevHwdb::new(udev)?;
 
     // vendor
-    let root_hub = hwdb.query("usb:v1D6B").ok_or(Error::UdevHwdb("no matching entry found for usb:v1D6B".into()))?
+    let root_hub = hwdb
+        .query("usb:v1D6B")
+        .ok_or(Error::UdevHwdb(
+            "no matching entry found for usb:v1D6B".into(),
+        ))?
         .iter()
         .find(|e| e.name() == "ID_VENDOR_FROM_DATABASE")
         .map(|e| (e.value()));
@@ -22,16 +26,23 @@ fn parse_hwdb() -> Result<()> {
     assert_eq!(root_hub, Some("Linux Foundation"));
 
     // pci in example
-    let pci = hwdb.query("pci:v00008086d00001C2D*").ok_or(Error::UdevHwdb("no matching entry found for pci:v00008086d00001C2D".into()))?
+    let pci = hwdb
+        .query("pci:v00008086d00001C2D*")
+        .ok_or(Error::UdevHwdb(
+            "no matching entry found for pci:v00008086d00001C2D".into(),
+        ))?
         .iter()
         .find(|e| e.name() == "ID_VENDOR_FROM_DATABASE")
         .map(|e| (e.value()));
 
     assert_eq!(pci, Some("Intel Corporation"));
 
-
     // vendor and product
-    let root_hub_30 = hwdb.query("usb:v1D6Bp0003").ok_or(Error::UdevHwdb("no matching entry found for usb:v1D6Bp0003".into()))?
+    let root_hub_30 = hwdb
+        .query("usb:v1D6Bp0003")
+        .ok_or(Error::UdevHwdb(
+            "no matching entry found for usb:v1D6Bp0003".into(),
+        ))?
         .iter()
         .find(|e| e.name() == "ID_MODEL_FROM_DATABASE")
         .map(|e| (e.value()));
@@ -39,7 +50,11 @@ fn parse_hwdb() -> Result<()> {
     assert_eq!(root_hub_30, Some("3.0 root hub"));
 
     // class
-    let hid = hwdb.query("usb:v*p*d*dc03*").ok_or(Error::UdevHwdb("no matching entry found for usb:v*p*d*dc03*".into()))?
+    let hid = hwdb
+        .query("usb:v*p*d*dc03*")
+        .ok_or(Error::UdevHwdb(
+            "no matching entry found for usb:v*p*d*dc03*".into(),
+        ))?
         .iter()
         .find(|e| e.name() == "ID_USB_CLASS_FROM_DATABASE")
         .map(|e| (e.value()));
@@ -47,15 +62,29 @@ fn parse_hwdb() -> Result<()> {
     assert_eq!(hid, Some("Human Interface Device"));
 
     // specific class, subclass and protocol
-    let query = hwdb.query("usb:v*p*d*dc03dsc01dp01dp01").ok_or(Error::UdevHwdb("no matching entry found for usb:v*p*d*dc03*dsc01".into()))?;
-    let subclass = query.iter().find(|e| e.name() == "ID_USB_SUBCLASS_FROM_DATABASE").map(|e| (e.value()));
-    let protocol = query.iter().find(|e| e.name() == "ID_USB_PROTOCOL_FROM_DATABASE").map(|e| (e.value()));
+    let query = hwdb
+        .query("usb:v*p*d*dc03dsc01dp01dp01")
+        .ok_or(Error::UdevHwdb(
+            "no matching entry found for usb:v*p*d*dc03*dsc01".into(),
+        ))?;
+    let subclass = query
+        .iter()
+        .find(|e| e.name() == "ID_USB_SUBCLASS_FROM_DATABASE")
+        .map(|e| (e.value()));
+    let protocol = query
+        .iter()
+        .find(|e| e.name() == "ID_USB_PROTOCOL_FROM_DATABASE")
+        .map(|e| (e.value()));
 
     assert_eq!(subclass, Some("Boot Interface Subclass"));
     assert_eq!(protocol, Some("Keyboard"));
 
     // class, subclass and protocol wildcard at end
-    let at = hwdb.query("usb:v*p*d*dc02dsc02dp05*").ok_or(Error::UdevHwdb("no matching entry found for usb:v*p*d*dc02dsc02dp05*".into()))?
+    let at = hwdb
+        .query("usb:v*p*d*dc02dsc02dp05*")
+        .ok_or(Error::UdevHwdb(
+            "no matching entry found for usb:v*p*d*dc02dsc02dp05*".into(),
+        ))?
         .iter()
         .find(|e| e.name() == "ID_USB_PROTOCOL_FROM_DATABASE")
         .map(|e| (e.value()));

--- a/tests/hwdb.rs
+++ b/tests/hwdb.rs
@@ -13,19 +13,46 @@ fn parse_hwdb() -> Result<()> {
 
     let mut hwdb = UdevHwdb::new(udev)?;
 
-    let _ = hwdb
-        .get_properties_list_entry("usb:v1D6Bp0001", 0)
-        .ok_or(Error::UdevHwdb("no matching entry found".into()))?;
-
-    let exp = ("ID_VENDOR_FROM_DATABASE", "Linux Foundation");
-
-    let found = hwdb
-        .properties_list()
+    // vendor
+    let root_hub = hwdb.query("usb:v1D6B").ok_or(Error::UdevHwdb("no matching entry found for usb:v1D6B".into()))?
         .iter()
-        .find(|e| e.value() == "Linux Foundation")
-        .map(|e| (e.name(), e.value()));
+        .find(|e| e.name() == "ID_VENDOR_FROM_DATABASE")
+        .map(|e| (e.value()));
 
-    assert_eq!(found, Some(exp));
+    assert_eq!(root_hub, Some("Linux Foundation"));
+
+    // pci in example
+    let pci = hwdb.query("pci:v00008086d00001C2D*").ok_or(Error::UdevHwdb("no matching entry found for pci:v00008086d00001C2D".into()))?
+        .iter()
+        .find(|e| e.name() == "ID_VENDOR_FROM_DATABASE")
+        .map(|e| (e.value()));
+
+    assert_eq!(pci, Some("Intel Corporation"));
+
+
+    // vendor and product
+    let root_hub_30 = hwdb.query("usb:v1D6Bp0003").ok_or(Error::UdevHwdb("no matching entry found for usb:v1D6Bp0003".into()))?
+        .iter()
+        .find(|e| e.name() == "ID_MODEL_FROM_DATABASE")
+        .map(|e| (e.value()));
+
+    assert_eq!(root_hub_30, Some("3.0 root hub"));
+
+    // class
+    let hid = hwdb.query("usb:v*p*d*dc03*").ok_or(Error::UdevHwdb("no matching entry found for usb:v*p*d*dc03*".into()))?
+        .iter()
+        .find(|e| e.name() == "ID_USB_CLASS_FROM_DATABASE")
+        .map(|e| (e.value()));
+
+    assert_eq!(hid, Some("Human Interface Device"));
+
+    // class, subclass and protocol
+    let at = hwdb.query("usb:v*p*d*dc02dsc02dp05*").ok_or(Error::UdevHwdb("no matching entry found for usb:v*p*d*dc02dsc02dp05*".into()))?
+        .iter()
+        .find(|e| e.name() == "ID_USB_PROTOCOL_FROM_DATABASE")
+        .map(|e| (e.value()));
+
+    assert_eq!(at, Some("AT-commands (3G)"));
 
     Ok(())
 }

--- a/tests/hwdb.rs
+++ b/tests/hwdb.rs
@@ -64,3 +64,23 @@ fn parse_hwdb() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn invalid_queries() -> Result<()> {
+    common::init();
+
+    std::env::set_var("UDEV_HWDB_BIN", "./hwdb.bin");
+    let udev = Arc::new(Udev::new());
+
+    let mut hwdb = UdevHwdb::new(udev)?;
+    let query = hwdb.query("");
+    assert!(query.is_none());
+
+    let query = hwdb.query("*x*");
+    assert!(query.is_none());
+
+    let query = hwdb.query("null:v1D6B");
+    assert!(query.is_none());
+
+    Ok(())
+}

--- a/tests/hwdb.rs
+++ b/tests/hwdb.rs
@@ -46,7 +46,15 @@ fn parse_hwdb() -> Result<()> {
 
     assert_eq!(hid, Some("Human Interface Device"));
 
-    // class, subclass and protocol
+    // specific class, subclass and protocol
+    let query = hwdb.query("usb:v*p*d*dc03dsc01dp01dp01").ok_or(Error::UdevHwdb("no matching entry found for usb:v*p*d*dc03*dsc01".into()))?;
+    let subclass = query.iter().find(|e| e.name() == "ID_USB_SUBCLASS_FROM_DATABASE").map(|e| (e.value()));
+    let protocol = query.iter().find(|e| e.name() == "ID_USB_PROTOCOL_FROM_DATABASE").map(|e| (e.value()));
+
+    assert_eq!(subclass, Some("Boot Interface Subclass"));
+    assert_eq!(protocol, Some("Keyboard"));
+
+    // class, subclass and protocol wildcard at end
     let at = hwdb.query("usb:v*p*d*dc02dsc02dp05*").ok_or(Error::UdevHwdb("no matching entry found for usb:v*p*d*dc02dsc02dp05*".into()))?
         .iter()
         .find(|e| e.name() == "ID_USB_PROTOCOL_FROM_DATABASE")


### PR DESCRIPTION
Closes #25. After some digging around [sd-hwdb.c](https://github.com/systemd/systemd/blob/main/src/libsystemd/sd-hwdb/sd-hwdb.c) the culprit for this bug was something silly as always! The `start` and `end` vars, obtained based on the passed start value and null terminator was using the `search` query rather than `prefix`. This values are used to generate the slice added to the `Line` and [should use `prefix`](https://github.com/systemd/systemd/blob/main/src/libsystemd/sd-hwdb/sd-hwdb.c#L186).

What made the results odd, was the fact that the passed `search` in the Rust udev would not even have a null terminator since it's a Rust String; it would always result in the `unwrap_or(search.len())`. So the prefix being searched was a slice based on the passed `p` and length of search. The result was a mostly correct trie line but not always and sometimes with too much/little matching. 

I made some other changes whilst debugging I think make sense for readability and robustness. Also adds the `system-hwdb` example and examples the hwdb parser tests. Outstanding question:

* I had multiple matches of the same key so changed `unique` to default `true`: https://github.com/cr8t/udev/compare/main...tuna-f1sh:udev:main?expand=1#diff-06060802aa63cf0eea53aba4bb5b2c88a0b96d2dc21bbe7a7736d21e31b127b5R31 . I'm not sure if this is your intent or not? Can also check in the `add_property` function if the key exists. [systemd actually has some logic for priority of multiple matches](https://github.com/systemd/systemd/blob/main/src/libsystemd/sd-hwdb/sd-hwdb.c#L133) which would take a lot of changes to implement. 