### PR TITLE
bump package versions for env_logger, nix and heapless

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ license = "LGPL-2.0-or-later"
 [dependencies]
 bitflags = "2.4"
 glob = "0.3"
-heapless = "0.7"
+heapless = "0.8"
 libc = "0.2"
 log = "0.4"
 
 [dependencies.nix]
-version = "0.27"
+version = "0.29"
 features = ["ioctl"]
 
 [dev-dependencies]
-env_logger = "0.10"
+env_logger = "0.11"


### PR DESCRIPTION
taken from: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/udevrs/debian/patches/relax-deps.patch?ref_type=heads