### PR TITLE
version: bump to `0.4.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udevrs"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["udev Rust Developers"]
 description = "Pure Rust implementation of the user-land udev library"

--- a/src/context.rs
+++ b/src/context.rs
@@ -343,8 +343,7 @@ mod tests {
             assert_eq!(prop, exp_prop);
         }
 
-        let exp_udev =
-            Udev::with_properties_list(Arc::clone(&mut null_udev), exp_prop_list.clone());
+        let exp_udev = Udev::with_properties_list(null_udev.clone(), exp_prop_list.clone());
 
         for (prop, exp_prop) in exp_udev
             .properties_list()

--- a/src/device.rs
+++ b/src/device.rs
@@ -1823,13 +1823,13 @@ impl UdevDevice {
         } else if let Some(devname) = property.strip_prefix("DEVNAME=") {
             self.set_devnode(devname);
         } else if let Some(devlinks) = property.strip_prefix("DEVLINKS=") {
-            for link in devlinks.split(|s| s == ' ') {
+            for link in devlinks.split(' ') {
                 if !link.is_empty() && !link.starts_with('\0') {
                     self.add_devlink(link);
                 }
             }
         } else if let Some(tags) = property.strip_prefix("TAGS=") {
-            for tag in tags.split(|s| s == ':') {
+            for tag in tags.split(':') {
                 if !tag.is_empty() && !tag.starts_with('\0') {
                     self.add_tag(tag)?;
                 }

--- a/src/util/device_nodes.rs
+++ b/src/util/device_nodes.rs
@@ -5,8 +5,8 @@ pub fn whitelisted_char_for_devnode(c: char, white: &str) -> bool {
     c.is_ascii_digit()
         || c.is_ascii_uppercase()
         || c.is_ascii_lowercase()
-        || "#+-.:=@_".contains(|s| s == c)
-        || white.contains(|s| s == c)
+        || "#+-.:=@_".contains(c)
+        || white.contains(c)
 }
 
 /// Encodes a `devnode` name, removing potentially dangerous characters.
@@ -14,9 +14,10 @@ pub fn encode_devnode_name(arg: &str) -> Result<String> {
     if arg.is_empty() {
         Err(Error::UdevUtil("empty encode string".into()))
     } else {
-        let mut ret = String::with_capacity(arg.as_bytes().len().saturating_mul(4));
+        let arg_len = arg.len();
+        let mut ret = String::with_capacity(arg_len.saturating_mul(4));
         // check for a nul-terminated string
-        let null_pos = arg.find(|c| c == '\0').unwrap_or(arg.len());
+        let null_pos = arg.find('\0').unwrap_or(arg_len);
 
         for c in arg[..null_pos].chars() {
             let seqlen = c.len_utf8();


### PR DESCRIPTION
Bumps the minor release version to `v0.4.0`.

Includes:

- fixes for `hwdb` search matching
- additional `hwdb` tests
- updated dependencies
- updated `hwdb` line search
- fallible `trie_string` method
- better support for 32-bit builds

Contributors:

- John Whittington <git@jbrengineering.co.uk>
- Alexander Kjäll <alexander.kjall@gmail.com>
- cr8t