### PR TITLE
monitor: pass std::io::Error errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,8 +15,7 @@ pub enum Error {
     UdevEnumerate(String),
     UdevQueue(String),
     UdevUtil(String),
-    Io(String),
-    StdIo {
+    Io {
         kind: std::io::ErrorKind,
         err: String,
     },
@@ -24,9 +23,17 @@ pub enum Error {
 
 impl Error {
     /// Convenience function to create a I/O error.
-    pub fn std_io<S: Into<String>>(kind: std::io::ErrorKind, err: S) -> Self {
-        Self::StdIo {
+    pub fn io<S: Into<String>>(kind: std::io::ErrorKind, err: S) -> Self {
+        Self::Io {
             kind,
+            err: err.into(),
+        }
+    }
+
+    /// Convenience function to create a I/O error.
+    pub fn io_other<S: Into<String>>(err: S) -> Self {
+        Self::Io {
+            kind: std::io::ErrorKind::Other,
             err: err.into(),
         }
     }
@@ -34,7 +41,7 @@ impl Error {
     /// Gets the [ErrorKind](std::io::ErrorKind).
     pub fn kind(&self) -> std::io::ErrorKind {
         match self {
-            Self::StdIo { kind, .. } => *kind,
+            Self::Io { kind, .. } => *kind,
             _ => std::io::ErrorKind::Other,
         }
     }
@@ -42,14 +49,14 @@ impl Error {
 
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Self {
-        Self::Io(format!("{err}"))
+        Self::io(err.kind(), format!("{err}"))
     }
 }
 
 impl From<Error> for std::io::Error {
     fn from(err: Error) -> Self {
         match err {
-            Error::StdIo { kind, err } => Self::new(kind, err),
+            Error::Io { kind, err } => Self::new(kind, err),
             err => Self::new(err.kind(), format!("{err}")),
         }
     }
@@ -63,19 +70,19 @@ impl From<Error> for std::io::ErrorKind {
 
 impl From<std::array::TryFromSliceError> for Error {
     fn from(err: std::array::TryFromSliceError) -> Self {
-        Self::Io(format!("{err}"))
+        Self::io_other(format!("{err}"))
     }
 }
 
 impl From<glob::PatternError> for Error {
     fn from(err: glob::PatternError) -> Self {
-        Self::Io(format!("invalid glob pattern: {err}"))
+        Self::io_other(format!("invalid glob pattern: {err}"))
     }
 }
 
 impl From<std::ffi::NulError> for Error {
     fn from(err: std::ffi::NulError) -> Self {
-        Self::Io(format!("invalid FFI C-String: {err}"))
+        Self::io_other(format!("invalid FFI C-String: {err}"))
     }
 }
 
@@ -90,8 +97,7 @@ impl fmt::Display for Error {
             Self::UdevEnumerate(err) => write!(f, "udev enumerate: {err}"),
             Self::UdevQueue(err) => write!(f, "udev queue: {err}"),
             Self::UdevUtil(err) => write!(f, "udev util: {err}"),
-            Self::Io(err) => write!(f, "I/O: {err}"),
-            Self::StdIo { kind, err } => write!(f, "I/O: kind: {kind}, error: {err}"),
+            Self::Io { kind, err } => write!(f, "I/O: kind: {kind}, error: {err}"),
         }
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -75,6 +75,6 @@ pub fn name_to_handle_at(
 
         log::warn!("{errmsg}");
 
-        Err(Error::Io(errmsg))
+        Err(Error::io(errno.kind(), errmsg))
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,11 +17,11 @@ impl Udev {
         Ok(link
             .components()
             .next_back()
-            .ok_or(Error::Io("empty sys core link value".into()))?
+            .ok_or(Error::io_other("empty sys core link value"))?
             .as_os_str()
             .to_str()
-            .ok_or(Error::Io(
-                "sys core link OS string contains non-Unicode bytes".into(),
+            .ok_or(Error::io_other(
+                "sys core link OS string contains non-Unicode bytes",
             ))?
             .to_owned())
     }


### PR DESCRIPTION
Adds `Error::StdIo` variant to capture the `std::io::ErrorKind`, and error message.

Adds conversions from `Error` into the `std::io::Error` + `std::io::ErrorKind` types.

Replaces all uses of `Error::Io` with `Error::StdIo` variant, and changes the name of `Error::StdIo` to `Error::Io`.

Resolves: #18