### PR TITLE
version: bump to `v0.5.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udevrs"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["udev Rust Developers"]
 description = "Pure Rust implementation of the user-land udev library"


### PR DESCRIPTION
Bumps the minor version to `v0.5.0` for breaking changes.

Includes:

- changes to `Error` for better pass-through of `std::io::Error`
- changes to `UdevMonitor` to support downstream polling/async